### PR TITLE
Prevent discarding of useful parameters like port or debug when using SMT

### DIFF
--- a/lib/Emailesque.pm
+++ b/lib/Emailesque.pm
@@ -130,8 +130,6 @@ sub send {
             #    $Email::Send::Sendmail::SENDMAIL;
         }
         if (lc($settings->{driver}) eq lc("smtp")) {
-            if ($settings->{host} && $settings->{user} && $settings->{pass}) {
-                
                 my   @parameters = ();
                 push @parameters, 'Host' => $settings->{host} if $settings->{host};
                 push @parameters, 'Port'  => $settings->{port} if $settings->{port};
@@ -146,10 +144,6 @@ sub send {
                 push @parameters, 'Debug' => 1 if $settings->{debug};
                 
                 $self->{send_using} = ['SMTP', @parameters];
-            }
-            else {
-                $self->{send_using} = ['SMTP', Host => $settings->{host}];
-            }
         }
         if (lc($settings->{driver}) eq lc("qmail")) {
             $self->{send_using} = ['Qmail', $settings->{path}];


### PR DESCRIPTION
Prevent discarding of useful parameters like port or debug when using SMTP mailer without username and password.

Please, I have a project where host + port is all I need for sending email and debug doesn't have an affect
either.

Regards
               Racke