### PR TITLE
Add a 'files' param as complement to 'attach'

### DIFF
--- a/lib/Emailesque.pm
+++ b/lib/Emailesque.pm
@@ -110,10 +110,12 @@ the hashref of arguments to the keyword, constructor and/or the send method:
     reply_to => 'other_email@website.com'
 
     # attach files to the email
-    # set attechment name to undef to use the filename
     attach => [
         $filepath => $filename,
     ]
+
+    # attach files to the email - use the filename
+    files => [ '/path/to/a', '/path/to/b', ... ]
 
     # send additional (specialized) headers
     headers => {
@@ -313,6 +315,16 @@ sub _prepare_send {
                 else {
                   $stuff->attach_file($file);
                 }
+            }
+        }
+    }
+
+    # process attachments
+    if ($options->{files}) {
+        if (ref($options->{files}) eq "ARRAY") {
+            my $files = $options->{files};
+            foreach my $file (@$files) {
+                $stuff->attach_file($file);
             }
         }
     }


### PR DESCRIPTION
I find the 'attach' param slightly awkward when I just want to use the file's name.  I have to build an array like this
```
[
    '/path/to/a' => undef,
    '/path/to/b' => undef,
    ...,
]
```

Since Emailesque is a convenience wrapper, how about adding a 'files' param which is just an arrayref of files like this:
```
[ '/path/to/a', '/path/to/b', ... ]
```

Thats what this pr does.